### PR TITLE
Replace "Lab0" with "myorganization" in telegraf.conf

### DIFF
--- a/telegraf/telegraf.conf
+++ b/telegraf/telegraf.conf
@@ -8,6 +8,6 @@
 [[outputs.influxdb_v2]]
   urls = ["http://influxdb:8086"]
   token = "mytoken"  # Use the token specified in DOCKER_INFLUXDB_INIT_ADMIN_TOKEN
-  organization = "Lab0"  # Match the org name from your Docker Compose file
+  organization = "myorganization"  # Match the org name from your Docker Compose file
   bucket = "demo"  # Match the bucket name from your Docker Compose file
 


### PR DESCRIPTION
this fixes an issue where telegraf doesn't send data to influx because of an organization name mismatch.